### PR TITLE
Add bin exporter

### DIFF
--- a/BinExporter/CMakeLists.txt
+++ b/BinExporter/CMakeLists.txt
@@ -1,0 +1,59 @@
+cmake_minimum_required(VERSION 3.17)
+
+set(PROJECT "BinExporter")
+
+PROJECT(${PROJECT})
+
+set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+set(CMAKE_AUTOMOC ON)
+
+if(MSVC)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W3 /DWIN32 /EHsc /MP")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /NODEFAULTLIB:LIBCMT")
+    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MDd")
+    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MD")
+endif(MSVC)
+
+file(TO_CMAKE_PATH $ENV{HDPS_INSTALL_DIR} INSTALL_DIR)
+
+find_package(Qt5 COMPONENTS Widgets WebEngineWidgets REQUIRED)
+
+set(SOURCES
+    src/BinExporter.h
+    src/BinExporter.cpp
+    src/BinExporter.json
+)
+
+source_group( Plugin FILES ${SOURCES})
+
+include_directories("${INSTALL_DIR}/$<CONFIGURATION>/include/")
+
+add_library(${PROJECT} SHARED ${SOURCES})
+
+set_property(TARGET ${PROJECT} PROPERTY CXX_STANDARD 14)
+
+if(MSVC)
+    set(LIB_LINK_SUFFIX ".lib") 
+else()
+    set(LIB_LINK_SUFFIX "${CMAKE_SHARED_LIBRARY_SUFFIX}")
+endif(MSVC)
+set(HDPS_LINK_LIBRARY "${INSTALL_DIR}/$<CONFIGURATION>/lib/${CMAKE_SHARED_LIBRARY_PREFIX}HDPS_Public${LIB_LINK_SUFFIX}")
+set(POINTDATA_LINK_LIBRARY "${INSTALL_DIR}/$<CONFIGURATION>/lib/${CMAKE_SHARED_LIBRARY_PREFIX}PointData${LIB_LINK_SUFFIX}")   
+
+target_link_libraries(${PROJECT} Qt5::Widgets)
+target_link_libraries(${PROJECT} Qt5::WebEngineWidgets)
+target_link_libraries(${PROJECT} "${HDPS_LINK_LIBRARY}")
+target_link_libraries(${PROJECT} "${POINTDATA_LINK_LIBRARY}")
+
+install(TARGETS ${PROJECT}
+    RUNTIME DESTINATION Plugins COMPONENT PLUGINS
+    LIBRARY DESTINATION Plugins COMPONENT PLUGINS
+)
+
+add_custom_command(TARGET ${PROJECT} POST_BUILD
+    COMMAND "${CMAKE_COMMAND}"
+        --install ${CMAKE_BINARY_DIR}
+        --config $<CONFIGURATION>
+        --prefix ${INSTALL_DIR}/$<CONFIGURATION>
+)

--- a/BinExporter/src/.editorconfig
+++ b/BinExporter/src/.editorconfig
@@ -1,0 +1,10 @@
+# To learn more about .editorconfig see https://aka.ms/editorconfigdocs
+root = true
+
+# All files
+[*]
+indent_style = space
+
+# Cpp files
+[*.{h,cpp}]
+indent_size = 4

--- a/BinExporter/src/BinExporter.cpp
+++ b/BinExporter/src/BinExporter.cpp
@@ -1,0 +1,191 @@
+#include "BinExporter.h"
+
+#include "PointData.h"
+#include "Set.h"
+
+#include <QtCore>
+#include <QtDebug>
+#include <QInputDialog>
+#include <QFileDialog>
+#include <QSettings>
+#include <QFileInfo>
+
+#include <fstream>
+#include <iterator>
+#include <vector>
+#include <algorithm>
+
+Q_PLUGIN_METADATA(IID "nl.tudelft.BinExporter")
+
+
+// =============================================================================
+// View
+// =============================================================================
+
+BinExporter::~BinExporter(void)
+{
+
+}
+
+void BinExporter::init()
+{
+
+}
+
+void BinExporter::writeData()
+{
+	// Get all data set names from the core 
+	// currently only point data set 
+	std::vector<QString> dataSetNames = _core->requestAllDataNames(std::vector<hdps::DataType> {PointType});
+
+	// Let the user select one of those data sets
+	BinExporterDialog inputDialog(nullptr, dataSetNames);
+	inputDialog.setModal(true);
+	connect(&inputDialog, &BinExporterDialog::closeDialog, this, &BinExporter::dialogClosed);
+	int ok = inputDialog.exec();
+
+	if ((ok == QDialog::Accepted) && (_dataSetName != "")) {
+
+		// Let the user chose the save path
+		QSettings settings(QLatin1String{ "HDPS" }, QLatin1String{ "Plugins/" } +getKind());
+		const QLatin1String directoryPathKey("directoryPath");
+		const auto directoryPath = settings.value(directoryPathKey).toString() + "/";
+		QString fileName = QFileDialog::getSaveFileName(
+			nullptr, tr("Save data set"), directoryPath + _dataSetName + ".bin", tr("Binary file (*.bin);;All Files (*)"));
+
+		// Only continue when the dialog has not been not canceled and the file name is non-empty.
+		if (fileName.isNull() || fileName.isEmpty())
+		{
+			qDebug() << "BinExporter: No data written to disk - File name empty";
+			return;
+		}
+		else
+		{
+			// store the directory name
+			settings.setValue(directoryPathKey, QFileInfo(fileName).absolutePath());
+
+			// get data from core
+			DataContent dataContent = retrieveDataSetContent(_dataSetName);
+			writeVecToBinary(dataContent.dataVals, fileName);
+			writeInfoTextForBinary(fileName, dataContent);
+			qDebug() << "BinExporter: Data written to disk - File name: " << fileName;
+			return;
+		}
+	}
+	else
+	{
+		qDebug() << "BinExporter: No data written to disk - No data set selected";
+		return;
+	}
+}
+
+void BinExporter::dialogClosed(QString dataSetName, bool onlyIdices)
+{
+	_dataSetName = dataSetName;
+	_onlyIdices = onlyIdices;
+}
+
+DataContent BinExporter::retrieveDataSetContent(QString dataSetName) {
+	DataContent dataContent;
+
+	Points& points = _core->requestData<Points>(dataSetName);
+	std::vector<float> dataFromSet;
+
+	// Get number of enabled dimensions
+	unsigned int numDimensions = points.getNumDimensions();
+
+	if (_onlyIdices)
+	{
+		std::transform(points.indices.begin(), points.indices.end(), std::back_inserter(dataFromSet), [](int x) { return (float)x; });
+		dataContent.onlyIndices = true;
+	}
+	else
+	{
+		// Get indices of selected points
+		std::vector<unsigned int> pointIDsGlobal = points.indices;
+		// If points represent all data set, select them all
+		if (points.isFull()) {
+			std::vector<unsigned int> all(points.getNumPoints());
+			std::iota(std::begin(all), std::end(all), 0);
+
+			pointIDsGlobal = all;
+		}
+
+		// For all selected points, retrieve values from each dimension
+		dataFromSet.reserve(pointIDsGlobal.size() * numDimensions);
+
+		points.visitFromBeginToEnd([&dataFromSet, &pointIDsGlobal, &numDimensions](auto beginOfData, auto endOfData)
+		{
+			for (const auto& pointId : pointIDsGlobal)
+			{
+				for (unsigned int dimensionId = 0; dimensionId < numDimensions; dimensionId++)
+				{
+					const auto index = pointId * numDimensions + dimensionId;
+					dataFromSet.push_back(beginOfData[index]);
+				}
+			}
+		});
+	}
+
+	// Data content for writing to disk
+	dataContent.dataVals = dataFromSet;
+	dataContent.numDimensions = numDimensions;
+	dataContent.numPoints = points.getNumPoints();
+
+	if (points.isDerivedData())
+	{
+		dataContent.isDerived = true;
+
+		Points& sourceData = points.getSourceData<Points>(points);
+
+		dataContent.derivedFrom = sourceData.getName();
+		dataContent.sourceNumDimensions = sourceData.getNumDimensions();
+		dataContent.sourceNumPoints = sourceData.getNumPoints();
+	}
+
+	return dataContent;
+}
+
+template<typename T>
+void BinExporter::writeVecToBinary(std::vector<T> vec, QString writePath) {
+	std::ofstream fout(writePath.toStdString(), std::ofstream::out | std::ofstream::binary);
+	fout.write(reinterpret_cast<const char*>(vec.data()), vec.size() * sizeof(T));
+	fout.close();
+}
+
+
+void BinExporter::writeInfoTextForBinary(QString writePath, DataContent& dataContent) {
+	std::string infoText;
+	std::string fileName = QFileInfo(writePath).fileName().toStdString();
+
+	infoText += fileName + "\n";
+	infoText += "Num dimensions: " + std::to_string(dataContent.numDimensions) + "\n";
+	infoText += "Num data points: " + std::to_string(dataContent.numPoints) + "\n";
+	infoText += "Data type: float \n";			// currently hard=coded	
+
+	if (dataContent.isDerived)
+	{
+		infoText += "Derived: true \n";
+		infoText += "Source data: " + dataContent.derivedFrom.toStdString() + "\n";
+		infoText += "Num dimensions (source): " + std::to_string(dataContent.sourceNumDimensions) + "\n";
+		infoText += "Num data points (source): " + std::to_string(dataContent.sourceNumPoints) + "\n";
+	}
+
+	if (dataContent.onlyIndices)
+	{
+		infoText += "Contains only indices (e.g. of a selection) \n";
+	}
+
+	std::ofstream fout(writePath.section(".", 0, 0).toStdString() + ".txt");
+	fout << infoText;
+	fout.close();
+}
+
+// =============================================================================
+// Factory
+// =============================================================================
+
+WriterPlugin* BinExporterFactory::produce()
+{
+	return new BinExporter();
+}

--- a/BinExporter/src/BinExporter.h
+++ b/BinExporter/src/BinExporter.h
@@ -1,0 +1,145 @@
+#pragma once
+
+#include <WriterPlugin.h>
+
+#include <QDialog>
+#include <QCheckBox>
+#include <QHBoxLayout>
+#include <QPushButton>
+#include <QComboBox>
+#include <QSpinBox>
+#include <QLabel>
+#include <QLineEdit>
+#include <QCheckBox> 
+
+using namespace hdps::plugin;
+
+struct DataContent {
+	DataContent() : dataVals{}, numDimensions(0), numPoints(0), isDerived(false), onlyIndices(false), derivedFrom(""), sourceNumDimensions(0), sourceNumPoints(0) {};
+	std::vector<float> dataVals;
+	unsigned int numDimensions;
+	unsigned int numPoints;
+
+	bool isDerived;
+	bool onlyIndices;
+	QString derivedFrom;
+	unsigned int sourceNumDimensions;
+	unsigned int sourceNumPoints;
+};
+
+// =============================================================================
+// Loading input box
+// =============================================================================
+
+enum BinaryDataType
+{
+	FLOAT, UBYTE
+};
+
+class BinExporterDialog : public QDialog
+{
+	Q_OBJECT
+public:
+	BinExporterDialog(QWidget* parent, std::vector<QString> dataSetNames) :
+		QDialog(parent), writeButton(tr("Write file"))
+	{
+		setWindowTitle(tr("Binary Exporter"));
+
+		for (QString& dataSetName : dataSetNames)
+			dataSetsBox.addItem(dataSetName);
+
+		if (dataSetNames.size() == 0)
+			dataSetsBox.setEnabled(false);
+
+		QLabel* dataSetsLabel = new QLabel("DataSets");
+		QLabel* indicesLabel = new QLabel("Save only indices");
+
+		writeButton.setDefault(true);
+
+		connect(&writeButton, &QPushButton::pressed, this, &BinExporterDialog::closeDialogAction);
+		connect(this, &BinExporterDialog::closeDialog, this, &QDialog::accept);
+
+		QHBoxLayout *layout = new QHBoxLayout();
+		layout->addWidget(dataSetsLabel);
+		layout->addWidget(&dataSetsBox);
+		layout->addWidget(indicesLabel);
+		layout->addWidget(&saveIndices);
+		layout->addWidget(&writeButton);
+		setLayout(layout);
+	}
+
+signals:
+	void closeDialog(QString dataSetName, bool onlyIndices);
+
+public slots:
+	// Pass selected data set name from BinExporterDialog to BinExporter (dialogClosed)
+	void closeDialogAction() {
+		emit closeDialog(dataSetsBox.currentText(), saveIndices.isChecked());
+	}
+
+private:
+	QComboBox dataSetsBox;
+	QCheckBox saveIndices;
+	QPushButton writeButton;
+};
+
+// =============================================================================
+// View
+// =============================================================================
+
+class BinExporter : public QObject, public WriterPlugin
+{
+	Q_OBJECT
+public:
+	BinExporter() : WriterPlugin("BIN Exporter"), _dataSetName("") { }
+	~BinExporter(void) override;
+
+	void init() override;
+
+	void writeData() Q_DECL_OVERRIDE;
+
+public slots:
+	void dialogClosed(QString dataSetName, bool onlyIdices);
+
+private:
+	/*! Get data set contents from core
+	 *
+	 * \param dataSetName Data set name to request from core
+	*/
+	DataContent retrieveDataSetContent(QString dataSetName);
+
+	/*! Write vector contents to disk
+	 * Stores content in little endian binary form.
+	 * Overrides existing files with at the given path.
+	 *
+	 * \param vec Data to write to disk
+	 * \param writePath Target path
+	*/
+	template<typename T>
+	void writeVecToBinary(std::vector<T> vec, QString writePath);
+
+	void writeInfoTextForBinary(QString writePath, DataContent& dataContent);
+
+	QString _dataSetName;
+	bool _onlyIdices;
+
+};
+
+
+// =============================================================================
+// Factory
+// =============================================================================
+
+class BinExporterFactory : public WriterPluginFactory
+{
+	Q_INTERFACES(hdps::plugin::WriterPluginFactory hdps::plugin::PluginFactory)
+		Q_OBJECT
+		Q_PLUGIN_METADATA(IID   "nl.tudelft.BinExporter"
+			FILE  "BinExporter.json")
+
+public:
+	BinExporterFactory(void) {}
+	~BinExporterFactory(void) override {}
+
+	WriterPlugin* produce() override;
+};

--- a/BinExporter/src/BinExporter.json
+++ b/BinExporter/src/BinExporter.json
@@ -1,0 +1,6 @@
+{
+    "name" : "BIN Exporter",
+    "menuName" : "BIN (.bin)",
+    "version" : "1",
+    "dependencies" : ["Points"]
+}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,4 +7,4 @@ PROJECT(${PROJECT})
 add_definitions(-DQT_MESSAGELOGCONTEXT)
 
 add_subdirectory(BinLoader)
-#add_subdirectory(BinExporter)
+add_subdirectory(BinExporter)


### PR DESCRIPTION
Adds a binary exporter plugin.

Additionally to the .bin binary file of the data, a small header .txt is saved which stores some information about the dataset like number of points and dimensions to facilitate reusing the binary data.

There is the option to only export the indices of the points in a data set. This proved useful to me for exporting selections of embeddings.